### PR TITLE
fix mongodb connect string to use db

### DIFF
--- a/services/database.js
+++ b/services/database.js
@@ -8,7 +8,7 @@ const db = {
             base = process.env.MONGO_BASE,
             db   = process.env.MONGO_DBNAME
         const
-            mongoUri = `mongodb+srv://${user}:${pass}@${base}/?retryWrites=true&w=majority`
+            mongoUri = `mongodb+srv://${user}:${pass}@${base}/${db}?retryWrites=true&w=majority`
 
         mongoose.set('strictQuery', false);
 


### PR DESCRIPTION
This just imports the db variable to the connect string.
Before creating a new user was writing to the "Test" database instead of the correct database